### PR TITLE
expiremap no longer uses StoreWithExpire

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -52,8 +52,8 @@ func (s *TokenSource) Token() (*oauth2.Token, error) {
 		Expiry:       time.Now().Add(tokenExpire),
 	}
 
-	s.store.StoreWithExpire(accessTokenKey, token, tokenExpire)
-	s.store.StoreWithExpire(refreshTokenKey, token.RefreshToken, refreshExpire)
+	s.store.Store(accessTokenKey, token, expiremap.Expire(tokenExpire))
+	s.store.Store(refreshTokenKey, token.RefreshToken, expiremap.Expire(refreshExpire))
 
 	return token, nil
 }


### PR DESCRIPTION
When we try to get [tegofy](https://github.com/typetalk-gadget/tegofy), we get error messages below. 

```
../source/source.go:55:9: s.store.StoreWithExpire undefined (type expiremap.Map has no field or method StoreWithExpire)
../source/source.go:56:9: s.store.StoreWithExpire undefined (type expiremap.Map has no field or method StoreWithExpire)
```

It seems that go-typetalk-token-source doesn't support latest [expiremap](https://github.com/vvatanabe/expiremap) library.